### PR TITLE
Update jquery-patterns/event-delegation.html

### DIFF
--- a/jquery-patterns/event-delegation.html
+++ b/jquery-patterns/event-delegation.html
@@ -10,8 +10,7 @@
 $('a.trigger', $('#container')[0]).live('click', handlerFn)
 
 // preferred
-$('#container').delegate('click', 'a.trigger', handlerFn)
-
+$('#container').on('click', 'a.trigger', handlerFn)
 // reference
 // http://paulirish.com/2009/perf/
 </script>


### PR DESCRIPTION
As of jQuery 1.7, .delegate() has been superseded by the .on() method. Per http://api.jquery.com/delegate/
