### PR TITLE
Does javascript require us to swallow errors?

### DIFF
--- a/function-patterns/callback.html
+++ b/function-patterns/callback.html
@@ -18,11 +18,11 @@
 
 				var node = complexComputation();
 
-				// call if callback is callable
+				// call if callback is callable - this will swallow code errors if I pass in a wrong tyep of parameter - I don't know what is the "correct" way to fix it, but I strongly feel it is not the right way to swallow errors
 				if (typeof callback === "function") {
 					callback(node);
-				}
-
+				} 
+                                    
 				nodes.push(node);
 				return nodes;
 			};


### PR DESCRIPTION
I see all my colleagues are doing extactly the same as here - check parameters and swallow cosuming developers' errors. I wonder is this a typical javascript way to check parameters? These error swallowing code makes my life very tough, things either works fine or fails sliently.

Shouldn't the code throw execption when pamarater checking fail?
