### PR TITLE
Settings defaults options semantics

### DIFF
--- a/jquery-plugin-patterns/extend.html
+++ b/jquery-plugin-patterns/extend.html
@@ -28,9 +28,9 @@
 			$.fn.extend( {
 				pluginname: function( options ) {
 
-					this.defaultOptions = {};
+					this.defaults = {};
 
-					var settings = $.extend( {}, this.defaultOptions, options );
+					var settings = $.extend( {}, this.defaults, options );
 
 					return this.each( function() {
 

--- a/jquery-plugin-patterns/namespaced-starter.html
+++ b/jquery-plugin-patterns/namespaced-starter.html
@@ -34,7 +34,7 @@
 				base.init = function () {
 					base.myFunctionParam = myFunctionParam;
 
-					base.options = $.extend( {}, $.myNamespace.myPluginName.defaultOptions, options );
+					base.settings = $.extend( {}, $.myNamespace.myPluginName.defaults, options );
 
 					// Put your initialization code here
 
@@ -49,7 +49,7 @@
 				base.init();
 			};
 
-			$.myNamespace.myPluginName.defaultOptions = {
+			$.myNamespace.myPluginName.defaults = {
 				myDefaultValue: ""
 			};
 


### PR DESCRIPTION
There are two commits in this pull request, which speaks to the jQuery Plugins Patterns section.

The chronologically first commit is a whitespace cleanup for consistency and to adhere to a standard; I chose the jQuery core standards.

The second commit cleanly separates the concepts of 
- **Options**: provided by the user
- **Defaults**: provided by the plugin
- **Settings**: the eventual amalgamated run-state of the plugin for its execution.
