### PR TITLE
Whitespace normalization, followed by a semantic cleanup 

### DIFF
--- a/jquery-plugin-patterns/best-options.html
+++ b/jquery-plugin-patterns/best-options.html
@@ -15,39 +15,42 @@
 
 		;(function ( $, window, document, undefined ) {
 
-		    $.fn.pluginName = function ( options ) {
+			$.fn.pluginName = function ( options ) {
 
-		        // Here's a best practice for overriding 'defaults'
-		        // with specified options. Note how, rather than a
-		        // regular defaults object being passed as the second
-		        // parameter, we instead refer to $.fn.pluginName.options
-		        // explicitly, merging it with the options passed directly
-		        // to the plugin. This allows us to override options both
-		        // globally and on a per-call level. 
+				// Here's a best practice for overriding 'defaults'
+				// with specified options. Note how, rather than a
+				// regular options object being passed as the second
+				// parameter, we instead refer to $.fn.pluginName.defaults
+				// explicitly, merging it with the options passed to the 
+				// plugin. This allows us to override defaults both
+				// globally and on a per-call level. 
 
-		        options = $.extend( {}, $.fn.pluginName.options, options );
+				settings = $.extend( {}, $.fn.pluginName.defaults, options );
 
-		        return this.each(function () {
+				return this.each( function () {
 
-		            var elem = $(this);
+					var elem = $( this );
 
-		        });
-		    };
+				});
+			};
 
-		    // Globally overriding options
-		    // Here are our publicly accessible default plugin options
-		    // that are available in case the user doesn't pass in all
-		    // of the values expected. The user is given a default
-		    // experience but can also override the values as necessary.
-		    // eg. $fn.pluginName.key ='otherval';
+			// Globally overriding options
+			// Here are the publicly accessible defaults
+			// in case the user doesn't pass-in any or all
+			// possible options. The user is given a default
+			// experience but can optionally override the values 
+			// as required.
+			// eg. $fn.pluginName.key ='otherval';
 
-		    $.fn.pluginName.options = {
+			$.fn.pluginName.defaults = {
 
-		        key: "value",
-		        myMethod: function ( elem, param ) {
+				key: "value",
+				myMethod: function ( elem, param ) {
 
-		        }
-		    };
+					// to do: implement myMethod() here
+
+				}
+			};
 
 		})( jQuery, window, document );
 


### PR DESCRIPTION
As with Pull Request 47, this is about options, defaults, and settings.

Please see [pull request 47](https://github.com/shichuan/javascript-patterns/pull/47) for some background on the semantics in-play here.

Note how separating the concepts of settings, defaults, and options allows us to make the comments more succinct.  That's because the concept of "options" isn't overloaded anymore.

**Options** come from the user.  **Defaults** come from the plugin.  **Settings** is what you run-with this time.

Signed-off-by: Steven Black steveb@stevenblack.com
