### PR TITLE
Fix typo in object-constants.html

### DIFF
--- a/object-creation-patterns/object-constants.html
+++ b/object-creation-patterns/object-constants.html
@@ -7,7 +7,7 @@
 	<body>
 		<script>
 			/* Title: Object Constants
-			 Description: an implementation of a contant object provides set, inDefined and get methods
+			 Description: an implementation of a constant object provides set, inDefined and get methods
 			 */
 
 			var constant = (function () {


### PR DESCRIPTION
As the title says, there was a typo in object-constants.html.
