### PR TITLE
Added both functions that are responsible for the output

### DIFF
--- a/jquery-patterns/pubsub-callback.html
+++ b/jquery-patterns/pubsub-callback.html
@@ -30,6 +30,14 @@
 			    return topic;
 			};
 
+			function fn1( value ){
+				console.log( value );
+			}
+
+			function fn2( value ){
+				fn1("fn2 says:" + value);
+				return false;
+			}
 
 			// Usage:
 			// Subscribers


### PR DESCRIPTION
These two functions are missing from the docu since it is not obvious where the output (especially the "fn2 says:" part). This adds the two functions as shown in the jQuery docs.
