### PR TITLE
Prefix selector caches with a dollar symbol

### DIFF
--- a/jquery-patterns/cache-selector.html
+++ b/jquery-patterns/cache-selector.html
@@ -17,10 +17,11 @@
 
 
 			// preferred
-			var photo;
+			var $photo;
+			// prefix the cache with $ to help identify it as a selector cache later
 			$('.list-item').click(function () {
-				photo = photo || $('.photo');
-				photo.hide();
+				$photo = $photo || $('.photo');
+				$photo.hide();
 			});
 
 


### PR DESCRIPTION
to help identify them as such later on in the code.

This is a fairly common jQuery pattern:

http://stackoverflow.com/questions/6209462/when-why-to-prefix-variables-with-when-using-jquery
http://encosia.com/5-steps-toward-jquery-mastery/
