### PR TITLE
Fix typo.

### DIFF
--- a/general-patterns/for-in-loops.html
+++ b/general-patterns/for-in-loops.html
@@ -55,7 +55,7 @@
 
 
 			// preferred 2
-			// benefit is you can avoid naming collisions is case the `man` object has redefined `hasOwnProperty`
+			// benefit is you can avoid naming collisions in case the `man` object has redefined `hasOwnProperty`
 			for (var i in man) {
 				if (Object.prototype.hasOwnProperty.call(man, i)) { // filter
 					console.log(i, ":", man[i]);


### PR DESCRIPTION
Fix typo at `general-patterns/for_in_loops`.
