### PR TITLE
removed misleading information about function declarations

### DIFF
--- a/general-patterns/function-declarations.html
+++ b/general-patterns/function-declarations.html
@@ -28,7 +28,6 @@
 			// named function expression
 			/* Benefits:
 			 * 1. Provides the debugger with an explicit function name: helps stack inspection.
-			 * 2. Allows recursive functions: getData can call itself.
 			 * Issues:
 			 * 1. Can break IE, coffeescript doesn't do function names:
 			 *    https://github.com/jashkenas/coffee-script/issues/366
@@ -39,8 +38,7 @@
                         // named function expression + 'F'
 			/* Benefits:
 			 * 1. Get's rid of (anonymous function) in stack traces
-			 * 2. Recurse by calling the name + 'F'
-			 * 3. Doesn't break an IE (well, unless there's a function name collision of the sort described here: https://github.com/jashkenas/coffee-script/issues/366#issuecomment-242134)
+			 * 2. Doesn't break an IE (well, unless there's a function name collision of the sort described here: https://github.com/jashkenas/coffee-script/issues/366#issuecomment-242134)
 			 */
 			var getData = function getDataF () {
 			};


### PR DESCRIPTION
Removed misleading comment information in the following examples:

``` javascript
var getData = function getData () {};
var getData = function getDataF () {};
```

In those examples the comments state that one of the benefits of those patterns is that they allow recursive functions. While that is true it is not a benefit of those examples over the others since all of the examples currently presented allow recursion.

The way the information is presented it implies that the pattern:

``` javascript
var getData = function () {};
```

does not allow recursive functions and that is not the case (this jsfiddle example might clarify that: http://jsfiddle.net/k6SSL/1/).

Furthermore one of the comments stated that one of the benefits of naming getDataF was that you can "Recurse by calling the name + 'F'". This suggests that we could not use recursion by calling getData() instead of getDataF() and we can (jsfiddle example: http://jsfiddle.net/4Pd9j/2/).
