### PR TITLE
Added missing object definition.

### DIFF
--- a/general-patterns/avoiding-eval.html
+++ b/general-patterns/avoiding-eval.html
@@ -11,12 +11,13 @@
 			 */
 
 			// antipattern 1
-			var property = "name";
+			var property = "name",
+			    obj = { name: "John" };
+
 			alert(eval("obj." + property));
 
 
 			// preferred 1
-			var property = "name";
 			alert(obj[property]);
 
 


### PR DESCRIPTION
I'm not a 100% sure on the placement of the object declaration as it falls under the "antipatern" heading and makes it look like you shouldn't declare or use the "single var" pattern.

Although, it might be better to let the reader figure it out.
