### PR TITLE
fix: 404 on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #JavaScript Patterns
 
-<img src="http://shichuan.github.io/javascript-patterns/img/js-patterns.png" alt="JS Patterns" title="JS Patterns" />
+<img src="https://chuanxshi.github.io/javascript-patterns/img/js-patterns.png" alt="JS Patterns" title="JS Patterns" />
 <br />
-Project page at: <a href="http://shichuan.github.io/javascript-patterns" target="_blank">http://shichuan.github.io/javascript-patterns</a>
+Project page at: <a href="https://chuanxshi.github.io/javascript-patterns" target="_blank">https://chuanxshi.github.io/javascript-patterns</a>
 


### PR DESCRIPTION
Due to name issue, the link is 404 for now.
The available link should be [https://chuanxshi.github.io/javascript-patterns/](https://chuanxshi.github.io/javascript-patterns/) rather than [https://shichuan.github.io/javascript-patterns/](https://shichuan.github.io/javascript-patterns/)

before:
<img width="878" alt="Screen Shot 2024-02-09 at 11 29 43 PM" src="https://github.com/chuanxshi/javascript-patterns/assets/107535020/5528aaa2-fcfe-4975-ac85-a826fbfd97c5">

after:
<img width="897" alt="Screen Shot 2024-02-09 at 11 29 01 PM" src="https://github.com/chuanxshi/javascript-patterns/assets/107535020/d24f564c-9d55-4d8a-903c-8d87fd34ee3e">
